### PR TITLE
Adding benchmark for comparing performance against cgo bindings.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -3,6 +3,9 @@ package farm
 import (
 	"strconv"
 	"testing"
+
+	// Farmhash from go bindings.
+	"github.com/dgryski/go-farmhash"
 )
 
 var res32 uint32
@@ -28,7 +31,22 @@ func BenchmarkHash32(b *testing.B) {
 			res32 = r
 		})
 	}
+}
 
+func BenchmarkCGoFarmhash32(b *testing.B) {
+	var r uint32
+
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			b.SetBytes(int64(n))
+			for i := 0; i < b.N; i++ {
+				// record the result to prevent the compiler eliminating the function call
+				r = farmhash.Hash32(buf[:n])
+			}
+			// store the result to a package level variable so the compiler cannot eliminate the Benchmark itself
+			res32 = r
+		})
+	}
 }
 
 func BenchmarkFingerprint32(b *testing.B) {
@@ -60,6 +78,19 @@ func BenchmarkHash64(b *testing.B) {
 		})
 	}
 
+}
+
+func BenchmarkCGoFarmhash64(b *testing.B) {
+	var r uint64
+
+	for _, n := range sizes {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				r = farmhash.Hash64(buf[:n])
+			}
+			res64 = r
+		})
+	}
 }
 
 func BenchmarkFingerprint64(b *testing.B) {


### PR DESCRIPTION
Results indicate that the overhead of calling cgo dominates for short
sizes. But for large sizes, the cgo implementation comes ahead.

Benchmarks for Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz:

BenchmarkHash32/16-4       	76447575	        15.4 ns/op
	1040.68 MB/s
BenchmarkHash32/32-4       	55358246	        19.9 ns/op
	1609.59 MB/s
BenchmarkHash32/40-4       	55792857	        20.1 ns/op
	1994.27 MB/s
BenchmarkHash32/60-4       	43029861	        25.4 ns/op
	2363.48 MB/s
BenchmarkHash32/64-4       	38531652	        31.4 ns/op
	2037.20 MB/s
BenchmarkHash32/72-4       	34881678	        30.6 ns/op
	2353.69 MB/s
BenchmarkHash32/80-4       	39112774	        31.0 ns/op
	2578.68 MB/s
BenchmarkHash32/100-4      	31341204	        35.3 ns/op
	2835.98 MB/s
BenchmarkHash32/150-4      	24348016	        49.3 ns/op
	3040.51 MB/s
BenchmarkHash32/200-4      	20150414	        59.8 ns/op
	3345.89 MB/s
BenchmarkHash32/250-4      	16181864	        73.4 ns/op
	3407.31 MB/s
BenchmarkHash32/512-4      	 7803576	       147 ns/op
	3481.27 MB/s
BenchmarkHash32/1024-4     	 4217576	       267 ns/op
	3832.27 MB/s
BenchmarkHash32/8192-4     	  593901	      1942 ns/op
	4217.89 MB/s
BenchmarkCGoFarmhash32/16-4         	13318178	        95.1
ns/op	 168.20 MB/s
BenchmarkCGoFarmhash32/32-4         	12028802	        93.9
ns/op	 340.91 MB/s
BenchmarkCGoFarmhash32/40-4         	12774854	        92.5
ns/op	 432.26 MB/s
BenchmarkCGoFarmhash32/60-4         	12280821	       103
ns/op	 581.35 MB/s
BenchmarkCGoFarmhash32/64-4         	10820432	        98.1
ns/op	 652.37 MB/s
BenchmarkCGoFarmhash32/72-4         	11496954	       100
ns/op	 718.33 MB/s
BenchmarkCGoFarmhash32/80-4         	11123570	        98.9
ns/op	 808.52 MB/s
BenchmarkCGoFarmhash32/100-4        	10972196	       106
ns/op	 942.93 MB/s
BenchmarkCGoFarmhash32/150-4        	 9696628	       120
ns/op	1251.03 MB/s
BenchmarkCGoFarmhash32/200-4        	 8780136	       128
ns/op	1563.83 MB/s
BenchmarkCGoFarmhash32/250-4        	 7914958	       144
ns/op	1732.65 MB/s
BenchmarkCGoFarmhash32/512-4        	 5895634	       205
ns/op	2503.09 MB/s
BenchmarkCGoFarmhash32/1024-4       	 3665587	       315
ns/op	3248.42 MB/s
BenchmarkCGoFarmhash32/8192-4       	  602181	      1915
ns/op	4278.25 MB/s
BenchmarkHash64/16-4                	121190888
9.89 ns/op
BenchmarkHash64/32-4                	96294661	        11.4
ns/op
BenchmarkHash64/40-4                	62262714	        17.5
ns/op
BenchmarkHash64/60-4                	62453169	        16.1
ns/op
BenchmarkHash64/64-4                	65704662	        16.4
ns/op
BenchmarkHash64/72-4                	35538782	        31.2
ns/op
BenchmarkHash64/80-4                	33494071	        31.2
ns/op
BenchmarkHash64/100-4               	21751887	        50.8
ns/op
BenchmarkHash64/150-4               	17689668	        65.8
ns/op
BenchmarkHash64/200-4               	14182575	        82.0
ns/op
BenchmarkHash64/250-4               	14387606	        80.4
ns/op
BenchmarkHash64/512-4               	12784395	        89.8
ns/op
BenchmarkHash64/1024-4              	 7730895	       151
ns/op
BenchmarkHash64/8192-4              	 1000000	      1031
ns/op
BenchmarkCGoFarmhash64/16-4         	13303598	        83.6
ns/op
BenchmarkCGoFarmhash64/32-4         	13203582	        84.9
ns/op
BenchmarkCGoFarmhash64/40-4         	12852262	        86.7
ns/op
BenchmarkCGoFarmhash64/60-4         	13560609	        85.6
ns/op
BenchmarkCGoFarmhash64/64-4         	13557555	        86.2
ns/op
BenchmarkCGoFarmhash64/72-4         	12916797	        89.3
ns/op
BenchmarkCGoFarmhash64/80-4         	12254312	        89.1
ns/op
BenchmarkCGoFarmhash64/100-4        	11918374	        97.4
ns/op
BenchmarkCGoFarmhash64/150-4        	11218617	       103
ns/op
BenchmarkCGoFarmhash64/200-4        	 9964280	       113
ns/op
BenchmarkCGoFarmhash64/250-4        	10745155	       115
ns/op
BenchmarkCGoFarmhash64/512-4        	 9192811	       135
ns/op
BenchmarkCGoFarmhash64/1024-4       	 7037410	       165
ns/op
BenchmarkCGoFarmhash64/8192-4       	 1698025	       697
ns/op